### PR TITLE
Added a useful note to query, and search docs.

### DIFF
--- a/api-reference/query.mdx
+++ b/api-reference/query.mdx
@@ -8,3 +8,5 @@ Submit a natural language query about the codebase, **get a natural language ans
 1. "How does auth work in this codebase?"
 2. "Generate a description for the JIRA ticket with codebase context"
 3. "Rewrite this code snippet using relevant abstractions already in the repo"
+
+Note: Before Greptile can query a repo, it must be indexed. See [Index Repository](/api-reference/index) for more information.

--- a/api-reference/search.mdx
+++ b/api-reference/search.mdx
@@ -10,3 +10,5 @@ Submit a natural language query about the codebase, get a list of relevant code 
 1. "Code to provision new API keys"
 2. "Functions that use recursion"
 3. "Code that touches session management in any way"
+
+Note: Before Greptile can search a repo, it must be indexed. See [Index Repository](/api-reference/index) for more information.


### PR DESCRIPTION
Whenever using the Greptile API for the first time I tried to query a repo before indexing it, so added a note here. 

Before change: 
![Screenshot (190)](https://github.com/user-attachments/assets/b7a901ba-ee2e-40d2-a61e-3dc31238dee2)

After Change: 
![Screenshot (189)](https://github.com/user-attachments/assets/f517c041-0193-4322-934a-a88cec62a9f3)
