### PR TITLE
fix: correct accordion syntax in nitpicks documentation

### DIFF
--- a/how-greptile-works/nitpicks.mdx
+++ b/how-greptile-works/nitpicks.mdx
@@ -122,23 +122,23 @@ graph TD
 
 ### What Gets Suppressed vs. What Doesn't
 
-<Accordion>
-<AccordionItem title="✅ Gets Suppressed (if consistently ignored)">
+<AccordionGroup>
+<Accordion title="✅ Gets Suppressed (if consistently ignored)">
 - Style/formatting issues
 - Import organization
 - Missing documentation (non-critical)
 - Naming convention deviations
 - Code organization preferences
-</AccordionItem>
+</Accordion>
 
-<AccordionItem title="🚫 Never Gets Suppressed">
+<Accordion title="🚫 Never Gets Suppressed">
 - Security vulnerabilities
 - Memory leaks
 - Infinite loops
 - Null pointer exceptions
 - Data validation missing from user inputs
-</AccordionItem>
 </Accordion>
+</AccordionGroup>
 
 ## The Result: Focused Reviews
 


### PR DESCRIPTION
  ## Summary

  Fixed broken accordion component syntax in the nitpicks documentation page.

  ## Problem

  The accordion component in the "What Gets Suppressed vs. What Doesn't" section was not rendering correctly on the documentation site. The syntax used was
   incompatible with Mintlify's accordion implementation.

  ## Solution

  - Changed from `<Accordion>` / `<AccordionItem>` to the correct Mintlify syntax using `<AccordionGroup>` and `<Accordion>`
  - This ensures the content displays properly with collapsible sections as intended

  ## Testing

  - Verified the accordion renders correctly in the Mintlify preview
  - Content remains semantically organized with clear separation between suppressed and never-suppressed items
