### PR TITLE
Fix link in greptile-json.mdx

### DIFF
--- a/code-review-bot/greptile-json.mdx
+++ b/code-review-bot/greptile-json.mdx
@@ -8,7 +8,7 @@ metaDescription: 'Learn how to customize Greptile settings and patterns for indi
 
 You can have custom settings at the repo level by adding a `greptile.json` file to the root of the repo in your default branch. 
 
-You can grab your global settings in the correct format [here](https://app.greptile.com/login) by clicking on the `copy` or `download` icons on the top right of the Settings panel. 
+You can grab your global settings in the correct format [here](https://app.greptile.com/review/github?tab=config) by clicking on the `copy` or `download` icons on the top right of the Settings panel. 
 
 <Note>
   The `ignorePatterns` field follows `.gitignore` [syntax](https://git-scm.com/docs/gitignore).


### PR DESCRIPTION
This link just goes to log in which is confusing, but the correct link does exist :)