### PR TITLE
Update developer-quick-reference - prompt indexing check

### DIFF
--- a/developer-quick-reference.mdx
+++ b/developer-quick-reference.mdx
@@ -61,6 +61,7 @@ metaDescription: 'Practical guide for developers on how to effectively use Grept
 - Your changes might be in excluded files or directories
 - Try manual trigger with `@greptileai` comment
 - Ask your team admin to check dashboard settings
+- Ensure your PR's repository is enabled and indexed in Greptile settings
 
 ## How do I give it more context?
 


### PR DESCRIPTION
Was wondering why Greptile was not reviewing our PRs - then found that our repos are still being indexed.

I assume that's the reason, but let me know if not!