### PR TITLE
Fix all wordings to align with agent

### DIFF
--- a/archive/apps/code-review.mdx
+++ b/archive/apps/code-review.mdx
@@ -144,6 +144,6 @@ Note: The `ignorePatterns` field follows `.gitignore` [syntax](https://git-scm.c
 **Patterns repos**
 
 In the `greptile.json` file, you can specify a `patternsRepo` field with repos related to the one being reviewed that might add helpful context. 
-An example is adding a frontend repo to a backend repo's `greptile.json` file so that the bot can reference frontend code when reviewing backend code.
+An example is adding a frontend repo to a backend repo's `greptile.json` file so that the agent can reference frontend code when reviewing backend code.
 
 To learn more, see [greptile.com/code-review-bot](https://www.greptile.com/code-review-bot).

--- a/developer-quick-reference.mdx
+++ b/developer-quick-reference.mdx
@@ -130,7 +130,7 @@ metaDescription: 'Practical guide for developers on how to effectively use Grept
 - Can reference patterns from anywhere in your repository
 - Understands how your changes fit into the bigger picture
 
-## Chatting with the bot with follow-up questions
+## Chatting with the agent with follow-up questions
 
 **How do I ask follow-up questions?**
 - Reply to any Greptile comment with `@greptileai <your question>`


### PR DESCRIPTION
Noticed not all wording was successfully transitioned to use `agent`.